### PR TITLE
Optimize the two-stage method cost function

### DIFF
--- a/src/DiffEqParamEstim.jl
+++ b/src/DiffEqParamEstim.jl
@@ -13,8 +13,8 @@ include("cost_functions.jl")
 include("lm_fit.jl")
 include("build_loss_objective.jl")
 include("build_lsoptim_objective.jl")
-include("two_stage_method.jl")
 include("kernels.jl")
+include("two_stage_method.jl")
 include("multiple_shooting_objective.jl")
 
 end # module

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -1,6 +1,19 @@
 # Kernel definition is taken from here: https://en.wikipedia.org/wiki/Kernel_(statistics)#Kernel_functions_in_common_use
 
-function Epanechnikov_kernel(t)
+abstract type CollocationKernel end
+struct EpanechnikovKernel <: CollocationKernel end
+struct UniformKernel <: CollocationKernel end
+struct TriangularKernel <: CollocationKernel end
+struct QuarticKernel <: CollocationKernel end
+struct TriweightKernel <: CollocationKernel end
+struct TricubeKernel <: CollocationKernel end
+struct GaussianKernel <: CollocationKernel end
+struct CosineKernel <: CollocationKernel end
+struct LogisticKernel <: CollocationKernel end
+struct SigmoidKernel <: CollocationKernel end
+struct SilvermanKernel <: CollocationKernel end
+
+function calckernel(::EpanechnikovKernel,t)
     if abs(t) > 1
         return 0
     else
@@ -8,7 +21,7 @@ function Epanechnikov_kernel(t)
     end
 end
 
-function Uniform_kernel(t)
+function calckernel(::UniformKernel,t)
     if abs(t) > 1
         return 0
     else
@@ -16,7 +29,7 @@ function Uniform_kernel(t)
     end
 end
 
-function Triangular_kernel(t)
+function calckernel(::TriangularKernel,t)
     if abs(t) > 1
         return 0
     else
@@ -24,7 +37,7 @@ function Triangular_kernel(t)
     end
 end
 
-function Quartic_Kernel(t)
+function calckernel(::QuarticKernel,t)
   if abs(t)>0
     return 0
   else
@@ -32,7 +45,7 @@ function Quartic_Kernel(t)
   end
 end
 
-function Triweight_Kernel(t)
+function calckernel(::TriweightKernel,t)
   if abs(t)>0
     return 0
   else
@@ -40,7 +53,7 @@ function Triweight_Kernel(t)
   end
 end
 
-function Tricube_Kernel(t)
+function calckernel(::TricubeKernel,t)
   if abs(t)>0
     return 0
   else
@@ -48,11 +61,11 @@ function Tricube_Kernel(t)
   end
 end
 
-function Gaussian_Kernel(t)
+function calckernel(::GaussianKernel,t)
   exp(-0.5*t^2)/(sqrt(2*π))
 end
 
-function Cosine_Kernel(t)
+function calckernel(::CosineKernel,t)
   if abs(t)>0
     return 0
   else
@@ -60,14 +73,14 @@ function Cosine_Kernel(t)
   end
 end
 
-function Logistic_Kernel(t)
+function calckernel(::LogisticKernel,t)
   1/(exp(t)+2+exp(-t))
 end
 
-function Sigmoid_Kernel(t)
+function calckernel(::SigmoidKernel,t)
   2/(π*(exp(t)+exp(-t)))
 end
 
-function Silverman_Kernel(t)
+function calckernel(::SilvermanKernel,t)
   sin(abs(t)/2+π/4)*0.5*exp(-abs(t)/sqrt(2))
 end

--- a/src/kernels.jl
+++ b/src/kernels.jl
@@ -1,7 +1,5 @@
 # Kernel definition is taken from here: https://en.wikipedia.org/wiki/Kernel_(statistics)#Kernel_functions_in_common_use
 
-export Epanechnikov_kernel, Uniform_kernel, Triangular_kernel, Quartic_Kernel, Triweight_Kernel, Tricube_Kernel, Gaussian_Kernel, Cosine_Kernel, Logistic_Kernel, Sigmoid_Kernel, Silverman_Kernel
-
 function Epanechnikov_kernel(t)
     if abs(t) > 1
         return 0

--- a/src/two_stage_method.jl
+++ b/src/two_stage_method.jl
@@ -39,35 +39,36 @@ end
 
 
 function construct_t1(t,tpoints)
-    T1 = []
-    for i in 1:length(tpoints)
-        push!(T1,[1 tpoints[i]-t])
+    mapreduce(vcat,1:length(tpoints)) do i
+        [1 tpoints[i]-t]
     end
-    foldl(vcat,T1)
 end
 function construct_t2(t,tpoints)
-    T2 = []
-    for i in 1:length(tpoints)
-        push!(T2,[1 tpoints[i]-t (tpoints[i]-t)^2])
+    mapreduce(vcat,1:length(tpoints)) do i
+        [1 tpoints[i]-t (tpoints[i]-t)^2]
     end
-    foldl(vcat,T2)
 end
 function construct_w(t,tpoints,h,kernel_function)
-    n = length(tpoints)
-    W = zeros(n)
-    for i in 1:n
-        W[i] = kernel_function((tpoints[i]-t)/h)/h
-    end
+    W = @. kernel_function((tpoints-t)/h)/h
     Matrix(Diagonal(W))
 end
-function construct_estimated_solution_and_derivative!(estimated_solution,estimated_derivative,e1,e2,data,kernel_function,tpoints,h,n)
-  for i in 1:n
-      T1 = construct_t1(tpoints[i],tpoints)
-      T2 = construct_t2(tpoints[i],tpoints)
-      W = construct_w(tpoints[i],tpoints,h,kernel_function)
-      estimated_solution[:,i] = e1'*inv(T1'*W*T1)*T1'*W*data'
-      estimated_derivative[:,i] = e2'*inv(T2'*W*T2)T2'*W*data'
+function construct_estimated_solution_and_derivative!(data,kernel_function,tpoints)
+  _one = oneunit(first(data))
+  _zero = zero(first(data))
+  e1 = [_one;_zero]
+  e2 = [_zero;_one;_zero]
+  n = length(tpoints)
+  h = (n^(-1/5))*(n^(-3/35))*((log(n))^(-1/16))
+
+  x = map(tpoints) do _t
+      T1 = construct_t1(_t,tpoints)
+      T2 = construct_t2(_t,tpoints)
+      W = construct_w(_t,tpoints,h,kernel_function)
+      e2'*inv(T2'*W*T2)T2'*W*data',e1'*inv(T1'*W*T1)*T1'*W*data'
   end
+  estimated_derivative = reduce(hcat,transpose.(first.(x)))
+  estimated_solution = reduce(hcat,transpose.(last.(x)))
+  estimated_derivative,estimated_solution
 end
 
 function construct_cost_function(f,du,preview_est_sol,preview_est_deriv,tpoints)
@@ -90,14 +91,8 @@ function two_stage_method(prob::DiffEqBase.DEProblem,tpoints,data;kernel= :Epane
                           verbose = false,verbose_steps = 100,
                           autodiff_chunk = Val{ForwardDiff.pickchunksize(length(prob.p))})
     f = prob.f
-    n = length(tpoints)
-    h = (n^(-1/5))*(n^(-3/35))*((log(n))^(-1/16))
-    estimated_solution = zeros(size(data)[1],n)
-    estimated_derivative = zeros(size(data)[1],n)
     kernel_function = decide_kernel(kernel)
-    e1 = [1;0]
-    e2 = [0;1;0]
-    construct_estimated_solution_and_derivative!(estimated_solution,estimated_derivative,e1,e2,data,kernel_function,tpoints,h,n)
+    estimated_derivative,estimated_solution = construct_estimated_solution_and_derivative!(data,kernel_function,tpoints)
 
     # Step - 2
 

--- a/src/two_stage_method.jl
+++ b/src/two_stage_method.jl
@@ -95,6 +95,8 @@ function construct_oop_cost_function(f,du,preview_est_sol,preview_est_deriv,tpoi
   end
 end
 
+get_chunksize(cs::Type{Val{CS}}) where CS = CS
+
 function two_stage_method(prob::DiffEqBase.DEProblem,tpoints,data;kernel= EpanechnikovKernel(),
                           loss_func = L2Loss,mpg_autodiff = false,
                           verbose = false,verbose_steps = 100,
@@ -113,9 +115,9 @@ function two_stage_method(prob::DiffEqBase.DEProblem,tpoints,data;kernel= Epanec
     else
       cost_function = construct_oop_cost_function(f,du,preview_est_sol,preview_est_deriv,tpoints)
     end
-    
+
     if mpg_autodiff
-      gcfg = ForwardDiff.GradientConfig(cost_function, autodiff_prototype, autodiff_chunk)
+      gcfg = ForwardDiff.GradientConfig(cost_function, prob.p, ForwardDiff.Chunk{get_chunksize(autodiff_chunk)}())
       g! = (x, out) -> ForwardDiff.gradient!(out, cost_function, x, gcfg)
     else
       g! = (x, out) -> Calculus.finite_difference!(cost_function,x,out,:central)

--- a/test/out_of_place_odes.jl
+++ b/test/out_of_place_odes.jl
@@ -30,7 +30,7 @@ result = Optim.optimize(cost_function, 0.0, 10.0)
 
 # two-stage OOP regression test
 
-function ff(u, p, t)
+function ff(du, u, p, t)
     du .= p .* u
 end
 function ff(u, p, t)

--- a/test/out_of_place_odes.jl
+++ b/test/out_of_place_odes.jl
@@ -27,3 +27,26 @@ cost_function = build_loss_objective(prob,Tsit5(),L2Loss(t,data),
                                      maxiters=10000,verbose=false)
 import Optim
 result = Optim.optimize(cost_function, 0.0, 10.0)
+
+# two-stage OOP regression test
+
+function ff(u, p, t)
+    du .= p .* u
+end
+function ff(u, p, t)
+    p .* u
+end
+rc=62
+ps = repeat([-0.001], rc)
+tspan = (7.0, 84.0)
+u0 = 3.4 .+ ones(rc)
+t = collect(range(minimum(tspan), stop=maximum(tspan), length=157))
+prob = ODEProblem(ff, u0, tspan, ps)
+prob_oop = ODEProblem{false}(ff, u0, tspan, ps)
+data = Array(solve(prob, Tsit5(), saveat = t))
+ptest = ones(rc)
+
+obj_ts = two_stage_method(prob, t, data; kernel=:Sigmoid)
+@test obj_ts(ptest) ≈ 418.3400017500223
+obj_ts = two_stage_method(prob_oop, t, data; kernel=:Sigmoid)
+@test obj_ts(ptest) ≈ 418.3400017500223

--- a/test/out_of_place_odes.jl
+++ b/test/out_of_place_odes.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq
+using OrdinaryDiffEq, Test
 
 function LotkaVolterraTest_not_inplace(u,a,t)
     b,c,d = 1.0,3.0,1.0


### PR DESCRIPTION
Fixes https://github.com/SciML/DiffEqParamEstim.jl/issues/69

Before: 296.305 ms (58882 allocations: 725.37 MiB)
After: 9.999 μs (0 allocations: 0 bytes)

```julia
using LinearAlgebra, OrdinaryDiffEq, RecursiveArrayTools, DiffEqParamEstim
function f(du, u, p, t)
    du .= p .* u
end
rc=62
ps = repeat([-0.001], rc)
tspan = (7.0, 84.0)
u0 = 3.4 .+ randn(rc)
prob = ODEProblem(f, u0, tspan, ps)
sol = solve(prob, Tsit5())
t = collect(range(minimum(tspan), stop=maximum(tspan), length=157))
function generate_data(t)
  randomized = VectorOfArray([(sol(t[i]) + (.01randn(rc))) for i in 1:length(t)])
  data = convert(Array,randomized)
end
aggregate_data = convert(Array,VectorOfArray([generate_data(t) for i in 1:1]))
aggregate_data = reshape(aggregate_data, (rc, 157))
obj_ts = two_stage_method(prob, t, aggregate_data; kernel=:Sigmoid )
ptest = ones(rc)

using BenchmarkTools
@btime $obj_ts($ptest)
```