### PR TITLE
re-establish build_lsoptim_objective()

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,6 +31,7 @@ julia = "1.6"
 BlackBoxOptim = "a134a8b2-14d6-55f6-9291-3336d3ab0209"
 DelayDiffEq = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+LeastSquaresOptim = "0fc2ff8b-aaa3-5acd-a817-1944a5e08891"
 NLopt = "76087f3c-5699-56af-9a33-bf431cd00edd"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Optimization = "7f7a1694-90dd-40f0-9382-eb1efda571ba"
@@ -48,4 +49,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Test", "BlackBoxOptim", "DelayDiffEq", "ForwardDiff", "NLopt", "Optim",  "Optimization", "OptimizationBBO", "OptimizationNLopt", "OptimizationOptimJL", "OrdinaryDiffEq", "ParameterizedFunctions", "Random", "SciMLSensitivity", "StochasticDiffEq", "SteadyStateDiffEq", "Sundials", "Zygote"]
+test = ["Test", "BlackBoxOptim", "DelayDiffEq", "ForwardDiff", "LeastSquaresOptim", "NLopt", "Optim",  "Optimization", "OptimizationBBO", "OptimizationNLopt", "OptimizationOptimJL", "OrdinaryDiffEq", "ParameterizedFunctions", "Random", "SciMLSensitivity", "StochasticDiffEq", "SteadyStateDiffEq", "Sundials", "Zygote"]

--- a/src/DiffEqParamEstim.jl
+++ b/src/DiffEqParamEstim.jl
@@ -23,6 +23,7 @@ end
 
 include("cost_functions.jl")
 include("build_loss_objective.jl")
+include("build_lsoptim_objective.jl")
 include("kernels.jl")
 include("two_stage_method.jl")
 include("multiple_shooting_objective.jl")

--- a/src/build_lsoptim_objective.jl
+++ b/src/build_lsoptim_objective.jl
@@ -1,0 +1,17 @@
+export build_lsoptim_objective
+
+function build_lsoptim_objective(prob::DiffEqBase.DEProblem, t, data, alg;
+                                 prob_generator = STANDARD_PROB_GENERATOR,
+                                 kwargs...)
+    vec_data = vec(data)
+    data_length = length(vec_data)
+    cost_function = function (out, p)
+        tmp_prob = prob_generator(prob, p)
+        sol = solve(tmp_prob, alg; saveat = t, save_everystep = false, dense = false,
+                    kwargs...)
+        y = vec(sol)
+        y_excess = length(y) - data_length + 1
+        y = y[y_excess:length(y)]
+        out .= y .- vec_data
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using DiffEqParamEstim, Test
     include("tests_on_odes/test_problems.jl")
     include("tests_on_odes/l2loss_test.jl")
     include("tests_on_odes/optim_test.jl")
+    include("tests_on_odes/lsoptim_test.jl")
     include("tests_on_odes/nlopt_test.jl")
     include("tests_on_odes/two_stage_method_test.jl")
     include("tests_on_odes/regularization_test.jl")

--- a/test/tests_on_odes/lsoptim_test.jl
+++ b/test/tests_on_odes/lsoptim_test.jl
@@ -1,0 +1,36 @@
+using LeastSquaresOptim
+
+println("Use LeastSquaresOptim to fit the parameter")
+cost_function = build_lsoptim_objective(prob1, t, data, Tsit5(), verbose = false)
+x = [1.0]
+res = LeastSquaresOptim.optimize!(
+    LeastSquaresOptim.LeastSquaresProblem(
+        x = x,
+        f! = cost_function,
+        output_length = length(t) * length(prob1.u0),
+    ),
+    LeastSquaresOptim.Dogleg(LeastSquaresOptim.LSMR()),
+)
+@test result.minimizer[1] ≈ 1.5 atol = 3e-1
+cost_function = build_lsoptim_objective(prob2, t, data, Tsit5(), verbose = false)
+x = [1.3, 2.7]
+res = LeastSquaresOptim.optimize!(
+    LeastSquaresOptim.LeastSquaresProblem(
+        x = x,
+        f! = cost_function,
+        output_length = length(t) * length(prob2.u0),
+    ),
+    LeastSquaresOptim.Dogleg(LeastSquaresOptim.LSMR()),
+)
+@test res.minimizer ≈ [1.5; 3.0] atol = 3e-1
+cost_function = build_lsoptim_objective(prob3, t, data, Tsit5(), verbose = false)
+x = [1.3, 0.8, 2.8, 1.2]
+res = LeastSquaresOptim.optimize!(
+    LeastSquaresOptim.LeastSquaresProblem(
+        x = x,
+        f! = cost_function,
+        output_length = length(t) * length(prob3.u0),
+    ),
+    LeastSquaresOptim.Dogleg(LeastSquaresOptim.LSMR()),
+)
+@test res.minimizer ≈ [1.5; 1.0; 3.0; 1.0] atol = 3e-1


### PR DESCRIPTION
Hi, 

IMHO removing `build_lsoptim_objective()` breaks existing code unnecessarily. Moreover, this used to be in usage examples, and I did not find a clear upgrade recipe to the current version.



 