### PR TITLE
Add maxiters to regularization_tests to avoid timeout

### DIFF
--- a/test/tests_on_odes/regularization_test.jl
+++ b/test/tests_on_odes/regularization_test.jl
@@ -21,13 +21,13 @@ cost_function_3 = build_loss_objective(prob3, Tsit5(), L2Loss(t, data),
 
 println("Use Optim BFGS to fit the parameter")
 optprob = Optimization.OptimizationProblem(cost_function_1, [1.0])
-result = solve(optprob, Optim.BFGS())
+result = solve(optprob, Optim.BFGS(), maxiters = 500)
 @test result.u[1]≈1.5 atol=3e-1
 
 optprob = Optimization.OptimizationProblem(cost_function_2, [1.2, 2.7])
-result = solve(optprob, Optim.BFGS())
+result = solve(optprob, Optim.BFGS(), maxiters = 500)
 @test result.minimizer≈[1.5; 3.0] atol=3e-1
 
 optprob = Optimization.OptimizationProblem(cost_function_3, [1.3, 0.8, 2.8, 1.2])
-result = solve(optprob, Optim.BFGS())
+result = solve(optprob, Optim.BFGS(), maxiters = 500)
 @test result.minimizer≈[1.5; 1.0; 3.0; 1.0] atol=5e-1


### PR DESCRIPTION
Fixes #248 
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
