### PR TITLE
Document public API: add docstrings + docs entries

### DIFF
--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -12,4 +12,5 @@ pages = [
         "methods/optimization_based_methods.md",
         "methods/collocation_loss.md",
     ],
+    "API" => "api.md",
 ]

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,28 @@
+# API Reference
+
+This page documents the public API of DiffEqParamEstim.jl.
+
+## Objective Builders
+
+```@docs
+build_loss_objective
+multiple_shooting_objective
+two_stage_objective
+```
+
+## Cost Functions
+
+```@docs
+L2Loss
+LogLikeLoss
+Regularization
+TwoStageCost
+```
+
+## Helper Functions
+
+```@docs
+prior_loss
+colloc_grad
+l2lossgradient!
+```

--- a/src/build_loss_objective.jl
+++ b/src/build_loss_objective.jl
@@ -1,5 +1,48 @@
 export build_loss_objective
 
+"""
+    build_loss_objective(prob::SciMLBase.AbstractSciMLProblem, alg, loss,
+        adtype = SciMLBase.NoAD(), regularization = nothing, args...;
+        priors = nothing, prob_generator = STANDARD_PROB_GENERATOR, kwargs...)
+
+Build an `OptimizationFunction` that solves `prob` for a candidate parameter
+vector and reduces the resulting solution to a scalar via `loss`.
+
+The returned function has the signature `cost(p, _ = nothing)`. For each `p` it
+regenerates a problem with `prob_generator(prob, p)`, solves it with `alg`, and
+returns `loss(sol)`. When `loss` is an `L2Loss` or `LogLikeLoss`, the solve
+saves only at the loss timepoints (`saveat = loss.t`, `save_everystep = false`,
+`dense = false`); otherwise the solve uses the passed keyword arguments as-is.
+
+# Arguments
+
+  - `prob`: the `AbstractSciMLProblem` (ODE, SDE, DAE, DDE, ...) to solve.
+  - `alg`: the solver algorithm matching `prob`.
+  - `loss`: a callable mapping a solution to a scalar cost, e.g. [`L2Loss`](@ref)
+    or [`LogLikeLoss`](@ref), or any user-supplied `loss(sol)`.
+  - `adtype`: the automatic differentiation choice passed to `OptimizationFunction`
+    (defaults to `SciMLBase.NoAD()`).
+  - `regularization`: an optional callable of `p` added to the loss, e.g.
+    [`Regularization`](@ref). `nothing` (the default) adds no regularization.
+  - `args...`: extra positional arguments forwarded to `solve`.
+
+# Keyword Arguments
+
+  - `priors`: an array of univariate distributions (one per parameter) or a
+    multivariate distribution. When provided, the negative log prior computed by
+    [`prior_loss`](@ref) is added to the loss, turning the objective into a MAP
+    estimate.
+  - `prob_generator`: a function `(prob, p) -> newprob` used to build the problem
+    for each parameter vector. Defaults to `STANDARD_PROB_GENERATOR`, which
+    `remake`s `prob` with autodiff-compatible element types and the new `p`.
+  - `kwargs...`: extra keyword arguments forwarded to the differential equation
+    `solve`.
+
+# Returns
+
+An `OptimizationFunction` wrapping the cost function with `adtype`, ready to be
+used to construct an `OptimizationProblem`.
+"""
 function build_loss_objective(
         prob::SciMLBase.AbstractSciMLProblem, alg, loss,
         adtype = SciMLBase.NoAD(),

--- a/src/cost_functions.jl
+++ b/src/cost_functions.jl
@@ -1,6 +1,23 @@
 export L2Loss, Regularization, LogLikeLoss, prior_loss, l2lossgradient!,
     colloc_grad
 
+"""
+    Regularization(λ, penalty = L2Penalty())
+
+A regularization term for use with an objective builder such as
+[`build_loss_objective`](@ref).
+
+Calling a `Regularization` on a parameter vector `p` returns
+`λ * value(penalty, p)`, i.e. the penalty evaluated on `p` scaled by `λ`.
+The penalty is any penalty function from
+[PenaltyFunctions.jl](https://github.com/JuliaML/PenaltyFunctions.jl); when
+omitted it defaults to `L2Penalty()`, giving standard L2 (ridge) regularization.
+
+# Fields
+
+  - `λ`: the scalar weight applied to the penalty term.
+  - `penalty`: the penalty function evaluated on the parameter vector.
+"""
 struct Regularization{L, P} <: DiffEqBase.DECostFunction
     λ::L
     penalty::P
@@ -11,6 +28,19 @@ function (f::Regularization)(p)
     return f.λ * value(f.penalty, p)
 end
 
+"""
+    prior_loss(prior, p)
+
+Return the negative log prior of the parameter vector `p` under `prior`.
+
+If `eltype(prior) <: UnivariateDistribution`, `prior` is treated as a collection
+of univariate distributions and the result is `-sum(logpdf(prior[i], p[i]))`.
+Otherwise `prior` is treated as a single (multivariate) distribution and the
+result is `-logpdf(prior, p)`. Adding this term to a loss turns a maximum
+likelihood objective into a maximum a posteriori (MAP) objective; it is used
+internally by [`build_loss_objective`](@ref) and
+[`multiple_shooting_objective`](@ref) when `priors` is supplied.
+"""
 function prior_loss(prior, p)
     ll = 0.0
     if eltype(prior) <: UnivariateDistribution
@@ -23,6 +53,44 @@ function prior_loss(prior, p)
     return ll
 end
 
+"""
+    L2Loss(t, data; differ_weight = nothing, data_weight = nothing,
+        colloc_grad = nothing, dudt = nothing)
+
+An optimized L2-distance loss for fitting a differential equation solution to
+data. Calling an `L2Loss` on a solution `sol` returns the (weighted) sum of
+squared residuals between `sol` and `data` at the timepoints `t`, returning
+`Inf` if the solve was unsuccessful.
+
+# Arguments
+
+  - `t`: the timepoints at which the data are given.
+  - `data`: the measured values, where column `i` holds the state at `t[i]`. A
+    vector is reshaped to a `1 x N` matrix.
+
+# Keyword Arguments
+
+  - `data_weight`: a scalar or array of weights matching the size of `data`, used
+    to weight each squared residual. `nothing` (the default) gives uniform unit
+    weights. Minimizing a weighted `L2Loss` is equivalent to maximum likelihood
+    estimation of a heteroskedastic Normal likelihood.
+  - `differ_weight`: a scalar or array weight on the first-difference residuals
+    `sol[i] - sol[i-1]` against the data first differences, which smooths the
+    loss and can improve identifiability (e.g. for stochastic models). `nothing`
+    (the default) disables the first-difference term.
+  - `colloc_grad`: a matrix of collocation gradients for the data (see
+    [`colloc_grad`](@ref)). When supplied, an interpolation-derivative term is
+    added to the loss; combined with regularization this makes the loss
+    equivalent to a 4DVAR objective.
+  - `dudt`: a buffer used to accumulate the derivative estimates when
+    `colloc_grad` is used; allocated automatically when `colloc_grad` is given.
+
+# Fields
+
+  - `t`, `data`, `differ_weight`, `data_weight`, `colloc_grad`, `dudt`: as above.
+  - `du_buf`: an internal buffer for the derivative evaluation used with
+    `colloc_grad`.
+"""
 struct L2Loss{T, D, U, W, G, B} <: DiffEqBase.DECostFunction
     t::T
     data::D
@@ -176,7 +244,26 @@ function (f::L2Loss)(sol::SciMLBase.AbstractEnsembleSolution)
     return mean(f.(sol.u))
 end
 
-#t - 1xN array, data - mxN array, returns mxN array
+"""
+    colloc_grad(t, data)
+
+Estimate the time-derivative of `data` by spline collocation, for use as the
+`colloc_grad` argument of [`L2Loss`](@ref).
+
+For each state (row of `data`), a cubic (3rd order) `Dierckx.Spline1D` is fit to
+`data` against `t` and differentiated at the timepoints `t`. The per-timepoint
+derivatives are collected into a matrix of the same shape as `data`, where
+column `i` is the estimated derivative at `t[i]`.
+
+# Arguments
+
+  - `t`: the timepoints, a length-`N` vector.
+  - `data`: an `m x N` matrix of measured state values.
+
+# Returns
+
+An `m x N` matrix of the collocation-estimated derivatives.
+"""
 function colloc_grad(t::T, data::D) where {T, D}
     splines = [Dierckx.Spline1D(t, data[i, :]) for i in 1:size(data)[1]]
     grad = [Dierckx.derivative(spline, t[1:end]) for spline in splines]
@@ -185,6 +272,42 @@ function colloc_grad(t::T, data::D) where {T, D}
     return grad
 end
 
+"""
+    LogLikeLoss(t, data_distributions)
+    LogLikeLoss(t, data_distributions, diff_distributions)
+
+A negative log-likelihood loss for fitting a differential equation solution to a
+field of distributions. Calling a `LogLikeLoss` on a solution `sol` returns the
+negative total log-likelihood of `sol` under `data_distributions` at the
+timepoints `t` (so minimizing it performs maximum likelihood estimation),
+returning `Inf` if the solve was unsuccessful.
+
+There are two forms for `data_distributions`:
+
+  - If `data_distributions[i, j]` is a `UnivariateDistribution`, it gives the
+    likelihood at `t[i]` for component `j`.
+  - If `data_distributions[i]` is a `MultivariateDistribution`, it gives the
+    likelihood at `t[i]` over the full state vector.
+
+These distributions can be produced with `fit_mle` on a dataset against a chosen
+distribution type.
+
+# Arguments
+
+  - `t`: the timepoints at which the distributions apply.
+  - `data_distributions`: the field of likelihood distributions (a vector is
+    reshaped to a `1 x N` matrix).
+  - `diff_distributions`: an optional field of distributions placed on the
+    first-difference terms `sol[i] - sol[i-1]`, contributing an additional
+    log-likelihood term. When supplied via the three-argument constructor its
+    contribution is scaled by `weight = 1`.
+
+# Fields
+
+  - `t`, `data_distributions`, `diff_distributions`: as above.
+  - `weight`: the scalar weight applied to the first-difference log-likelihood
+    term (`nothing` when `diff_distributions` is not used).
+"""
 struct LogLikeLoss{T, D} <: DiffEqBase.DECostFunction
     t::T
     data_distributions::D
@@ -292,6 +415,27 @@ function (f::LogLikeLoss)(sol::SciMLBase.AbstractEnsembleSolution)
     return ll
 end
 
+"""
+    l2lossgradient!(grad, sol, data, sensitivities, num_p)
+
+Compute, in place, the gradient of an L2 loss with respect to `num_p`
+parameters and write it into `grad`.
+
+Given a solution `sol`, the target `data`, and the parameter `sensitivities`
+(where `sensitivities[i]` is the derivative of the solution with respect to
+parameter `i`), this accumulates
+`grad[i] -= sum(2 * (data - sol) .* sensitivities[i])` over all state components
+and timepoints. `grad` is zeroed before accumulation. Returns `nothing`.
+
+# Arguments
+
+  - `grad`: a length-`num_p` vector, overwritten with the loss gradient.
+  - `sol`: the solution values, shaped like `data`.
+  - `data`: the target data.
+  - `sensitivities`: a collection of length `num_p` of parameter sensitivities,
+    each shaped like `data`.
+  - `num_p`: the number of parameters.
+"""
 function l2lossgradient!(grad, sol, data, sensitivities, num_p)
     fill!(grad, 0.0)
     data_x_size = size(data, 1)

--- a/src/multiple_shooting_objective.jl
+++ b/src/multiple_shooting_objective.jl
@@ -21,6 +21,54 @@ struct Merged_Solution{T1, T2, T3}
     sol::T3
 end
 
+"""
+    multiple_shooting_objective(prob::SciMLBase.AbstractDEProblem, alg, loss,
+        adtype = SciMLBase.NoAD(), regularization = nothing;
+        priors = nothing, discontinuity_weight = 1.0,
+        prob_generator = STANDARD_MS_PROB_GENERATOR, kwargs...)
+
+Build an `OptimizationFunction` that fits parameters by multiple shooting.
+
+Multiple shooting splits `prob.tspan` into `K` shorter intervals and treats both
+the differential equation parameters and the initial state of each interval as
+optimization variables. The returned cost function solves each interval with
+`alg`, merges the segment solutions into a single trajectory, evaluates `loss`
+on it, and adds a discontinuity penalty for the mismatch between the end of each
+segment and the start of the next. This is often more robust than a single-shot
+objective, as in boundary value problems.
+
+The parameter vector `p` is laid out as the concatenation of the per-interval
+initial states followed by the `length(prob.p)` differential equation
+parameters; the default `prob_generator = STANDARD_MS_PROB_GENERATOR` slices `p`
+into the correct per-segment problems.
+
+# Arguments
+
+  - `prob`: the `AbstractDEProblem` to fit.
+  - `alg`: the solver algorithm matching `prob`.
+  - `loss`: a callable mapping the merged solution to a scalar, e.g.
+    [`L2Loss`](@ref) or [`LogLikeLoss`](@ref).
+  - `adtype`: the automatic differentiation choice passed to `OptimizationFunction`
+    (defaults to `SciMLBase.NoAD()`).
+  - `regularization`: an optional callable of `p` (e.g. [`Regularization`](@ref))
+    added to the loss; `nothing` (the default) adds none.
+
+# Keyword Arguments
+
+  - `priors`: univariate distributions (one per parameter) or a multivariate
+    distribution; when given, the negative log prior from [`prior_loss`](@ref)
+    over the differential equation parameters is added, giving a MAP objective.
+  - `discontinuity_weight`: a scalar or array weight on the squared mismatch
+    between consecutive segments (defaults to `1.0`).
+  - `prob_generator`: a function `(prob, p, k) -> segment_prob` producing the
+    problem for interval `k` from `p`. Defaults to `STANDARD_MS_PROB_GENERATOR`.
+  - `kwargs...`: extra keyword arguments forwarded to the differential equation
+    `solve`.
+
+# Returns
+
+An `OptimizationFunction` wrapping the multiple-shooting cost with `adtype`.
+"""
 function multiple_shooting_objective(
         prob::SciMLBase.AbstractDEProblem, alg, loss,
         adtype = SciMLBase.NoAD(),

--- a/src/two_stage_method.jl
+++ b/src/two_stage_method.jl
@@ -1,5 +1,24 @@
 export TwoStageCost, two_stage_objective
 
+"""
+    TwoStageCost(cost_function, estimated_solution, estimated_derivative)
+
+The callable cost object produced by [`two_stage_objective`](@ref).
+
+Calling a `TwoStageCost` on a parameter vector `p` forwards to
+`cost_function(p, _p)`, which measures how well the differential equation's
+right-hand side evaluated at the collocation-smoothed solution matches the
+collocation-smoothed derivative. The smoothed trajectory and its derivative are
+stored so they can be inspected after construction.
+
+# Fields
+
+  - `cost_function`: the underlying cost closure of signature `(p, _p = nothing)`.
+  - `estimated_solution`: the kernel-smoothed estimate of the state trajectory at
+    the collocation points.
+  - `estimated_derivative`: the kernel-smoothed estimate of the state derivative
+    at the collocation points.
+"""
 struct TwoStageCost{F, D} <: Function
     cost_function::F
     estimated_solution::D
@@ -97,6 +116,44 @@ function construct_oop_cost_function(f, du, preview_est_sol, preview_est_deriv, 
     end
 end
 
+"""
+    two_stage_objective(prob::SciMLBase.AbstractDEProblem, tpoints, data,
+        adtype = SciMLBase.NoAD(); kernel = EpanechnikovKernel())
+
+Build an `OptimizationFunction` for the two-stage (non-parametric collocation)
+parameter estimation method.
+
+The two-stage method avoids repeatedly solving the differential equation: it
+first builds a kernel-smoothed estimate of the state trajectory and its
+derivative from `data`, then measures, for a candidate `p`, the squared
+mismatch between the model right-hand side `prob.f` evaluated at the smoothed
+state and the smoothed derivative. It is less accurate than solve-based
+objectives but much faster, and is a good way to get into the neighborhood of
+good parameters before refining with another method.
+
+# Arguments
+
+  - `prob`: the `AbstractDEProblem` whose right-hand side is being fit. Both
+    in-place and out-of-place `prob.f` are supported.
+  - `tpoints`: the timepoints at which `data` is sampled.
+  - `data`: the measured state values used for the collocation smoothing.
+  - `adtype`: the automatic differentiation choice passed to `OptimizationFunction`
+    (defaults to `SciMLBase.NoAD()`).
+
+# Keyword Arguments
+
+  - `kernel`: the collocation smoothing kernel, either a `CollocationKernel`
+    instance or a `Symbol` selecting one (`:Epanechnikov`, `:Uniform`,
+    `:Triangular`, `:Quartic`, `:Triweight`, `:Tricube`, `:Gaussian`,
+    `:Cosine`, `:Logistic`, `:Sigmoid`, `:Silverman`). Defaults to
+    `EpanechnikovKernel()`.
+
+# Returns
+
+An `OptimizationFunction` wrapping a [`TwoStageCost`](@ref) with `adtype`. The
+returned cost also exposes the smoothed `estimated_solution` and
+`estimated_derivative`.
+"""
 function two_stage_objective(
         prob::SciMLBase.AbstractDEProblem, tpoints, data,
         adtype = SciMLBase.NoAD();


### PR DESCRIPTION
## Summary

Every exported (public) name in DiffEqParamEstim.jl previously had **no docstring** and **no rendered-docs entry**. This PR closes that gap for all ten:

`build_loss_objective`, `multiple_shooting_objective`, `two_stage_objective`, `L2Loss`, `LogLikeLoss`, `Regularization`, `TwoStageCost`, `prior_loss`, `colloc_grad`, `l2lossgradient!`.

## Changes

- **Docstrings** added to each public name, derived from the actual implementation (signature, what it does, arguments/fields/returns), in SciML style. Types (`L2Loss`, `LogLikeLoss`, `Regularization`, `TwoStageCost`) document their fields and constructors.
- **Docs entries**: new `docs/src/api.md` API-reference page with `@docs` blocks covering all ten names, wired into `docs/pages.jl` as an "API" section. (The repo previously had no `@docs`/`@autodocs` blocks at all.)

## Validation

- Loaded the package on Julia 1 and confirmed via `Base.Docs.meta` that all ten names now have an attached, non-empty docstring (before: none did).
- Built the new `api.md` page through `Documenter.makedocs` with `warnonly = false`; the `CheckDocument` and `CrossReferences` passes completed with no missing-docstring or unresolved-`@docs` errors, confirming every `@docs` entry resolves to a real docstring.
- Ran Runic on the changed source (no reformatting needed).

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)