### PR TITLE
Bump version to 2.4.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffEqParamEstim"
 uuid = "1130ab10-4a5a-5621-a13d-e4788d82bd4c"
-version = "2.4.0"
+version = "2.4.1"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (2.4.0 -> 2.4.1) to release unreleased commits on `master` via JuliaRegistrator.