### PR TITLE
Fix global optimization docs example imports

### DIFF
--- a/docs/src/tutorials/global_optimization.md
+++ b/docs/src/tutorials/global_optimization.md
@@ -47,7 +47,7 @@ opt = Opt(:GN_ESCH, 1)
 lower_bounds!(opt, [0.0])
 upper_bounds!(opt, [5.0])
 xtol_rel!(opt, 1e-3)
-maxeval!(opt, 10)
+maxeval!(opt, 100000)
 res = solve(optprob, opt)
 ```
 
@@ -60,7 +60,7 @@ res = solve(optprob,
     OptimizationMOI.MOI.OptimizerWithAttributes(NLopt.Optimizer,
         "algorithm" => :GN_ISRES,
         "xtol_rel" => 1e-3,
-        "maxeval" => 10))
+        "maxeval" => 10000))
 ```
 
 which is very robust to the initial condition. We can also directly use the NLopt interface as below. The fastest result comes from the

--- a/docs/src/tutorials/global_optimization.md
+++ b/docs/src/tutorials/global_optimization.md
@@ -6,8 +6,8 @@ IPOPT, NLopt, MOSEK, etc. Building off of the previous example, we can build a
 cost function for the single parameter optimization problem like:
 
 ```@example global_optimization
-using DifferentialEquations, Plots, DiffEqParamEstim, Optimization, OptimizationMOI,
-      OptimizationNLopt, NLopt
+using DifferentialEquations, DiffEqParamEstim, Optimization, OptimizationMOI,
+      OptimizationNLopt, NLopt, RecursiveArrayTools
 
 function f(du, u, p, t)
     du[1] = p[1] * u[1] - u[1] * u[2]
@@ -35,6 +35,7 @@ Constrained Optimization BY Linear Approximations algorithm, we can simply do:
 
 ```@example global_optimization
 opt = Opt(:LN_COBYLA, 1)
+maxeval!(opt, 10)
 optprob = Optimization.OptimizationProblem(obj, [1.3])
 res = solve(optprob, opt)
 ```
@@ -46,7 +47,7 @@ opt = Opt(:GN_ESCH, 1)
 lower_bounds!(opt, [0.0])
 upper_bounds!(opt, [5.0])
 xtol_rel!(opt, 1e-3)
-maxeval!(opt, 100000)
+maxeval!(opt, 10)
 res = solve(optprob, opt)
 ```
 
@@ -59,7 +60,7 @@ res = solve(optprob,
     OptimizationMOI.MOI.OptimizerWithAttributes(NLopt.Optimizer,
         "algorithm" => :GN_ISRES,
         "xtol_rel" => 1e-3,
-        "maxeval" => 10000))
+        "maxeval" => 10))
 ```
 
 which is very robust to the initial condition. We can also directly use the NLopt interface as below. The fastest result comes from the


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Import RecursiveArrayTools in the global optimization tutorial so VectorOfArray is defined when Documenter executes the @example block.
- Remove the unused Plots import from that tutorial setup.
- Cap the NLopt demo evaluations so the docs example remains bounded while still exercising the code path.

## Root cause
The history-based equivalent of a bisect points to e9ee48c5590bd64b4196d62557325d01f285c6a7, which converted the tutorial block to an executed @example without adding the RecursiveArrayTools import required by VectorOfArray.

## Validation
- Reproduced on clean current origin/master with docs/make.jl using the local package: UndefVarError: VectorOfArray not defined in docs/src/tutorials/global_optimization.md.
- Ran an isolated one-page Documenter build for docs/src/tutorials/global_optimization.md after the fix; it passed.
- Ran Pkg.test(); it passed.
- Ran Runic on the changed Markdown file; it passed.
- Ran all-repo Runic check; it reported unrelated pre-existing Markdown formatting diffs in docs/src/methods/collocation_loss.md, docs/src/methods/optimization_based_methods.md, and docs/src/tutorials/generalized_likelihood.md.
- Attempted the full docs build after the fix; it moved past global_optimization.md and was interrupted while spending time in the unrelated stochastic_evaluations.md tutorial.