### PR TITLE
Release prep: bump DiffEqParamEstim to 2.4.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DiffEqParamEstim"
 uuid = "1130ab10-4a5a-5621-a13d-e4788d82bd4c"
-version = "2.4.1"
+version = "2.4.2"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
 
 [deps]


### PR DESCRIPTION
Patch release for the accumulated docstring/QA/test-scaffolding changes since 2.4.1, plus a docs example import fix (#314).