### PR TITLE
Require strict SciMLTesting 2.4 QA

### DIFF
--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,15 +1,9 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DiffEqParamEstim = "1130ab10-4a5a-5621-a13d-e4788d82bd4c"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Aqua = "0.8"
-JET = "0.9,0.10,0.11"
-SafeTestsets = "0.1, 1"
 SciMLTesting = "2.4"
-Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,13 +1,3 @@
-using SciMLTesting, DiffEqParamEstim, JET, Test
+using SciMLTesting, DiffEqParamEstim
 
-run_qa(
-    DiffEqParamEstim;
-    ei_kwargs = (
-        # NoAD is owned by SciMLBase but not (yet) declared public there.
-        all_qualified_accesses_are_public = (;
-            ignore = (
-                :NoAD,  # SciMLBase
-            ),
-        ),
-    ),
-)
+run_qa(DiffEqParamEstim)


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

Removes the stale ExplicitImports exception for `SciMLBase.NoAD`, which is now public, and calls `run_qa(DiffEqParamEstim)` with the standard defaults. Keeps Aqua as a direct QA dependency because its ambiguity subprocess imports it in an isolated Julia process.

Validation:
- `Pkg.test()` passed on Julia 1.12 (all core groups; one pre-existing broken Optim test).
- Strict SciMLTesting 2.4 QA passed: 20/20.
- Documentation build and explicit Documenter doctests passed: 1/1.
- Runic and `git diff --check` passed.

The current `master` Documentation CI failure is separate: the docs build completes, then deployment fails because `DOCUMENTER_KEY` cannot authenticate to GitHub.