### PR TITLE
docs: enable Documenter doctests

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,7 +11,7 @@ makedocs(
     sitename = "DiffEqParamEstim.jl",
     authors = "Chris Rackauckas et al.",
     modules = [DiffEqParamEstim],
-    clean = true, doctest = false, linkcheck = true,
+    clean = true, linkcheck = true,
     format = Documenter.HTML(
         assets = ["assets/favicon.ico"],
         canonical = "https://docs.sciml.ai/DiffEqParamEstim/stable/"


### PR DESCRIPTION
Remove the repository-level `doctest = false` override so standard Documenter behavior executes the package's documented examples.

Verification:
- `julia --startup-file=no --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'`
- `julia --startup-file=no --project=docs docs/make.jl` (passed with doctests enabled)
- `GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` (20/20 QA)
- `julia --startup-file=no -m Runic --check docs/make.jl`
- `typos docs/make.jl`
- `git diff --check`

This is a docs-only configuration change. Please ignore this draft until reviewed by @ChrisRackauckas.