### PR TITLE
Fix DAE parameter estimation tests with BrownFullBasicInit

### DIFF
--- a/test/dae_tests.jl
+++ b/test/dae_tests.jl
@@ -1,6 +1,7 @@
 using DelayDiffEq, OrdinaryDiffEq, RecursiveArrayTools, Test,
     Sundials
 using OrdinaryDiffEqBDF: DFBDF
+using DiffEqBase: BrownFullBasicInit
 
 function f(out, du, u, p, t)
     out[1] = -p[1] * u[1] + 1.0e4 * u[2] * u[3] - du[1]
@@ -12,7 +13,8 @@ du₀ = [-0.04, 0.04, 0.0]
 tspan = (0.0, 100000.0)
 differential_vars = [true, true, false]
 prob = DAEProblem(f, du₀, u₀, tspan, [0.04], differential_vars = differential_vars)
-sol = solve(prob, DFBDF())
+init_alg = BrownFullBasicInit()
+sol = solve(prob, DFBDF(); initializealg = init_alg)
 
 t = collect(range(0, stop = 10, length = 30))
 randomized = VectorOfArray([(sol(t[i]) + 0.003randn(3)) for i in 1:length(t)])
@@ -23,7 +25,7 @@ using DiffEqParamEstim, OptimizationNLopt, OptimizationOptimJL, ForwardDiff, Zyg
 cost_function = build_loss_objective(
     prob, DFBDF(), L2Loss(t, data),
     Optimization.AutoZygote(), abstol = 1.0e-8,
-    reltol = 1.0e-8
+    reltol = 1.0e-8, initializealg = init_alg
 )
 optprob = Optimization.OptimizationProblem(cost_function, [0.01]; lb = [0.0], ub = [1.0])
 res = solve(optprob, OptimizationOptimJL.BFGS())
@@ -31,7 +33,7 @@ res = solve(optprob, OptimizationOptimJL.BFGS())
 cost_function = build_loss_objective(
     prob, DFBDF(), L2Loss(t, data),
     Optimization.AutoForwardDiff(), abstol = 1.0e-8,
-    reltol = 1.0e-8
+    reltol = 1.0e-8, initializealg = init_alg
 )
 optprob = Optimization.OptimizationProblem(cost_function, [0.01]; lb = [0.0], ub = [1.0])
 res = solve(optprob, OptimizationOptimJL.BFGS())


### PR DESCRIPTION
## Summary
- Use `BrownFullBasicInit` when solving the Robertson DAE in `dae_tests.jl` and pass the same `initializealg` through `build_loss_objective` for Zygote and ForwardDiff optimization paths.

## Root cause
CI fails in `Core/dae_tests` because parameter estimation re-solves the DAE with varying `p[1]` while keeping fixed `u0`/`du0`. Without an initialization algorithm, DiffEqBase 7 rejects inconsistent DAE initial conditions (`normresid` failure).

## Test plan
- [ ] Core test group (`Core/dae_tests`) on CI
- Local run blocked here by shared-depot precompile lock contention (~15 min SIGTERM); not a test failure.


Made with [Cursor](https://cursor.com)