### PR TITLE
Import NLopt in NLopt tests

### DIFF
--- a/test/nlopt_test.jl
+++ b/test/nlopt_test.jl
@@ -1,5 +1,5 @@
 using DiffEqParamEstim, OrdinaryDiffEq
-using Optimization, OptimizationNLopt, Zygote
+using Optimization, OptimizationNLopt, NLopt, Zygote
 include(joinpath(@__DIR__, "shared", "test_problems.jl"))
 
 println("Use NLOpt to fit the parameter")


### PR DESCRIPTION
> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Import `NLopt` directly in `nlopt_test.jl`. OptimizationNLopt intentionally stopped blanket-reexporting NLopt's solver-driving API, but this test still uses `lower_bounds!`, `upper_bounds!`, `xtol_rel!`, and `maxeval!` unqualified. NLopt is already a declared test dependency, so the direct import restores the test without changing package behavior or dependencies.

The OptimizationNLopt public-surface bisect identified commit `0c726c0cf0b2f4c150b26ca03c4117e8a35434af`, where `@reexport using NLopt` became `using NLopt`, as the first commit without those reexports. OptimizationNLopt 0.3.17 restores `Opt` and `Algorithm`, which is why the current failure reaches `lower_bounds!` rather than failing at `Opt`.

## Verification

### Failing before

On current `master` commit `8c85ebe4b2b039b0940c7156bacec3d63da82f5d`:

```console
$ GROUP=Core ~/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test()'
Test Summary:                            | Pass  Total   Time
Core/multiple_shooting_objective_test.jl |    3      3  52.6s
Use NLOpt to fit the parameter
Core/nlopt_test.jl: Error During Test
  LoadError: UndefVarError: `lower_bounds!` not defined
  Hint: a global variable of this name also exists in NLopt.
...
Test Summary:      | Pass  Error  Total  Time
Core/nlopt_test.jl |    1      1      2  3.8s
ERROR: Package DiffEqParamEstim errored during testing
```

### Passing after

After rebasing this one-line change onto the same `master` commit, the complete Core group passes with 43 assertions and the pre-existing intentionally broken assertion:

```console
$ GROUP=Core ~/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test()'
Test Summary:                            | Pass  Total   Time
Core/multiple_shooting_objective_test.jl |    3      3  51.1s
Use NLOpt to fit the parameter
Test Summary:      | Pass  Total   Time
Core/nlopt_test.jl |    4      4  16.1s
...
Test Summary:              | Pass  Total  Time
Core/weighted_loss_test.jl |    1      1  2.0s
     Testing DiffEqParamEstim tests passed
```

QA passes:

```console
$ GROUP=QA ~/.juliaup/bin/julia +release --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA/qa.jl      |   20     20  1m02.9s
     Testing DiffEqParamEstim tests passed
```

Formatting and spelling checks pass:

```console
$ ~/.julia/packages/Runic/2Ay9P/bin/runic --check .
$ git diff --check origin/master...HEAD
$ typos test/nlopt_test.jl
```

## Not verified / independent base failures

- Current-master Downgrade reaches `weighted_loss_test.jl`, then fails because minimum-version OptimizationNLopt 0.3.15 passes an `OptimizationFunction` directly to `NLopt.min_objective!`. This is independent of the import fixed here and is being bisected separately.
- Current-master Documentation completes doctests and the build, then fails to authenticate while fetching `git@github.com:SciML/DiffEqParamEstim.jl` for deployment. This is a deployment-credential failure, not a docs-build failure.
- Docs were not rebuilt locally because this changes neither docs, docstrings, public API, nor package code. `Everything`, GPU, downstream, and allowed-to-fail jobs were not run.

## Links

- Optimization.jl introducing commit: https://github.com/SciML/Optimization.jl/commit/0c726c0cf0b2f4c150b26ca03c4117e8a35434af
- Current master CI: https://github.com/SciML/DiffEqParamEstim.jl/actions/runs/33392092068
- Current master Downgrade: https://github.com/SciML/DiffEqParamEstim.jl/actions/runs/33392091778
- Current master Documentation: https://github.com/SciML/DiffEqParamEstim.jl/actions/runs/33392091784

🤖 Generated with Codex CLI 0.151.0 (model: gpt-5.6-sol; session: local session ID `01a04fa1-cfe0-7260-b416-72fe8a15d17d`).
