### PR TITLE
Fix multiple-shooting prior parameter slice

### DIFF
--- a/src/multiple_shooting_objective.jl
+++ b/src/multiple_shooting_objective.jl
@@ -119,7 +119,7 @@ function multiple_shooting_objective(
         )
         loss_val = loss(sol_new)
         if priors !== nothing
-            loss_val += prior_loss(priors, p[(end - length(priors)):end])
+            loss_val += prior_loss(priors, p[(end - length(priors) + 1):end])
         end
         if !isnothing(regularization)
             loss_val += regularization(p)

--- a/test/multiple_shooting_objective_test.jl
+++ b/test/multiple_shooting_objective_test.jl
@@ -10,6 +10,18 @@ ms_p = [1.5, 1.0]
 ms_prob = ODEProblem(ms_f, ms_u0, tspan, ms_p)
 t = collect(range(0, stop = 10, length = 200))
 data = Array(solve(ms_prob, Tsit5(), saveat = t, abstol = 1.0e-12, reltol = 1.0e-12))
+
+prior_prob = ODEProblem((u, p, t) -> zero(u), [0.0], (0.0, 1.0), [10.0, 20.0])
+prior_t = [0.0, 1.0]
+prior_data = zeros(1, 2)
+parameter_priors = [Normal(10.0, 1.0), Normal(20.0, 1.0)]
+prior_obj = multiple_shooting_objective(
+    prior_prob, Tsit5(), L2Loss(prior_t, prior_data),
+    Optimization.AutoForwardDiff(); priors = parameter_priors
+)
+prior_variables = [0.0, 10.0, 20.0]
+@test prior_obj(prior_variables) ≈ prior_loss(parameter_priors, prior_variables[(end - 1):end])
+
 bound = Tuple{Float64, Float64}[
     (0, 10), (0, 10), (
         0, 10,


### PR DESCRIPTION
## What changed and why

`multiple_shooting_objective` sliced one too many trailing decision variables when evaluating univariate parameter priors. With two priors, the old range selected the final shooting state plus both model parameters; `prior_loss` consumed the first two entries, so the priors were applied to a shooting state and the first parameter while leaving the second parameter unconstrained. This changes the range to select exactly the trailing `length(priors)` model parameters and adds a deterministic regression test that distinguishes the shooting state from those parameters.

The source defect was introduced in https://github.com/SciML/DiffEqParamEstim.jl/commit/62c956efea6db6bbdf61447f0478668317e04a14. The existing optimizer assertion began exposing it when https://github.com/SciML/DiffEqParamEstim.jl/commit/e95f58fc4aa62b6eaca7fc01704802f46c163908 removed its `broken = true` marker.

Ignore this PR until reviewed by @ChrisRackauckas.

## Verification

Failing before the fix, using the new deterministic test against unmodified `master` (`956f282`):

```text
Expression: objective(variables) ≈ prior_loss(priors, variables[end - 1:end])
 Evaluated: 101.83787706640935 ≈ 1.8378770664093456
Test Summary:                                    | Fail  Total  Time
multiple-shooting priors target model parameters |    1      1  0.4s
```

The clean full Core group independently reproduces the reported optimizer failure on the same commit:

```text
GROUP=Core julia --project -e 'using Pkg; Pkg.test()'
Core/multiple_shooting_objective_test.jl: Test Failed
 Evaluated: [0.5396896542545061, 0.24661733877558248] ≈ [1.5, 1.0] (atol=0.2)
Test Summary:                            | Pass  Fail  Total   Time
Core/multiple_shooting_objective_test.jl |    1     1      2  54.0s
```

Passing after the fix:

```text
Test Summary:                                    | Pass  Total  Time
multiple-shooting priors target model parameters |    1      1  0.2s
```

The affected Core file, including the previously failing optimizer assertion, passes:

```text
Test Summary:                            | Pass  Total   Time
Core/multiple_shooting_objective_test.jl |    3      3  59.0s
```

Local checks:

```text
julia --project=. /path/to/prior_regression_test.jl  # fails before; passes after
julia --compiled-modules=no --project=. test/multiple_shooting_objective_test.jl  # exit 0
GROUP=Core julia --compiled-modules=no --project -e 'using Pkg; Pkg.test()'  # target file 3/3, then unrelated NLopt baseline error
julia --project=/path/to/runic-1.9.0 -m Runic --check src/multiple_shooting_objective.jl test/multiple_shooting_objective_test.jl  # exit 0
typos src/multiple_shooting_objective.jl test/multiple_shooting_objective_test.jl  # exit 0
git diff HEAD^ --check  # exit 0
```

The documentation build also completed successfully against the local checkout:

```text
julia --compiled-modules=no --project=docs -e 'using Pkg; Pkg.develop(path=".")'
julia --compiled-modules=no --project=docs docs/make.jl
[ Info: CheckDocument: running document checks.
[ Info: RenderDocument: rendering document.
[ Info: HTMLWriter: rendering HTML pages.
```

The repository QA group passed:

```text
GROUP=QA julia --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA/qa.jl      |   20     20  1m07.5s
     Testing DiffEqParamEstim tests passed
```

CI documentation, QA, spelling, test detection, and Runic suggestions completed successfully. The Core workflow is https://github.com/SciML/DiffEqParamEstim.jl/actions/runs/33288500786 and the documentation job is https://github.com/SciML/DiffEqParamEstim.jl/actions/runs/33288500621/job/99195863179.

## Not verified

The full Core group does not complete on current `master`: CI on Julia 1, LTS, and pre passes this PR's affected file 3/3, then `test/nlopt_test.jl` errors because `lower_bounds!` is no longer re-exported. Those jobs are in https://github.com/SciML/DiffEqParamEstim.jl/actions/runs/33288500786. That independent baseline failure has a focused fix in https://github.com/SciML/DiffEqParamEstim.jl/pull/333.

CI downgrade also passes `Core/multiple_shooting_objective_test.jl` 3/3 and `Core/nlopt_test.jl` 4/4, then encounters a separate baseline `ODESolution` constructor error in `Core/out_of_place_odes.jl`. The affected file's passing job is https://github.com/SciML/DiffEqParamEstim.jl/actions/runs/33288500606/job/99195863201.

CI's repository-wide Runic check confirms both changed files are formatted and fails only on pre-existing formatting drift in `test/likelihood.jl`: https://github.com/SciML/DiffEqParamEstim.jl/actions/runs/33288500639/job/99195863285.

The behavior change deliberately treats the final `length(priors)` entries as model parameters, matching the objective's documented decision-variable layout and the multivariate-prior path.

🤖 Generated with Codex API (version unknown) (model: unknown). Session: local session ID `01a04fa1-cfe0-7260-b416-72fe8a15d17d`.
