### PR TITLE
Use OptimizationSolution.u in two-stage test

### DIFF
--- a/test/two_stage_method_test.jl
+++ b/test/two_stage_method_test.jl
@@ -17,7 +17,7 @@ result = Optim.optimize(cost_function, [1.3, 0.8, 2.8, 1.2], Optim.BFGS())
 obj = two_stage_objective(prob2, t, data, Optimization.AutoForwardDiff())
 optprob = OptimizationNLopt.OptimizationProblem(obj, [1.3, 0.8])
 result = solve(optprob, Optim.ConjugateGradient())
-@test result.minimizer ≈ [1.5; 3.0] atol = 3.0e-1
+@test result.u ≈ [1.5; 3.0] atol = 3.0e-1
 
 obj = two_stage_objective(prob2, t, data, Optimization.AutoForwardDiff())
 opt = Opt(:LD_LBFGS, 2)


### PR DESCRIPTION
## What changed and why

Use `OptimizationSolution.u` in the two-stage method test instead of the removed `minimizer` compatibility accessor. SciMLBase removed that deprecated accessor for v3, but the DiffEqParamEstim v3 migration updated the analogous regularization tests and missed this assertion.

> Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

Failure before, on upstream `dca73d251b3942c5bed2eb8719e580b4b577f391`, using a temporary local-only focused test selector:

```text
$ DIFFEQPARAMESTIM_FOCUSED_TWO_STAGE=true julia --project -e 'using Pkg; Pkg.test()'
two_stage_method_test: Error During Test at test/two_stage_method_test.jl:20
  FieldError: type OptimizationSolution has no field `minimizer`, available fields: `u`, `cache`, `alg`, `objective`, `retcode`, `original`, `stats`, `dual`
Test Summary:         | Pass  Error  Total
two_stage_method_test |    7      1      8
EXIT=1
```

The same focused test after this change:

```text
$ DIFFEQPARAMESTIM_FOCUSED_TWO_STAGE=true julia --project -e 'using Pkg; Pkg.test()'
Test Summary:         | Pass  Total
two_stage_method_test |    8      8
Testing DiffEqParamEstim tests passed
EXIT=0
```

QA:

```text
$ GROUP=QA julia --startup-file=no --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total
QA/qa.jl      |   20     20
Testing DiffEqParamEstim tests passed
EXIT=0
```

Core, with the independent NLopt import fix from https://github.com/SciML/DiffEqParamEstim.jl/pull/333 stacked for validation because current master stops earlier in `nlopt_test.jl`:

```text
$ GROUP=Core julia --startup-file=no --project -e 'using Pkg; Pkg.test()'
Core/nlopt_test.jl            | 4 pass
Core/regularization_test.jl   | 3 pass
Core/two_stage_method_test.jl | 8 pass
All Core files                | 43 pass, 1 pre-existing broken
Testing DiffEqParamEstim tests passed
EXIT=0
```

Static checks:

```text
$ julia +release --startup-file=no --project=@runic -m Runic --check test/two_stage_method_test.jl
EXIT=0
$ typos test/two_stage_method_test.jl
EXIT=0
$ git diff --check
EXIT=0
```

## Not verified

- Documentation was not built because this test-only change does not touch documentation or public API.
- Core cannot pass on unmodified master before this change is reached because of the independent NLopt import failure tracked by https://github.com/SciML/DiffEqParamEstim.jl/pull/333; the complete group was therefore also run with that fix stacked.
- The repository-wide Runic v1.10 check still reports only the independent pre-existing `test/likelihood.jl` formatting diff. That mechanical change is intentionally not mixed into this bug-fix PR.

## Reviewer note

The changed field is SciMLBase's public optimization-solution field; neighboring standardized `solve` assertions in this file already use `u`. Direct `Optim.optimize` results still correctly use `minimizer` and are unchanged.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d)
