### PR TITLE
Format for Runic v1.10

### DIFF
--- a/test/likelihood.jl
+++ b/test/likelihood.jl
@@ -33,9 +33,9 @@ result = solve(optprob, BBO_adaptive_de_rand_1_bin_radiuslimited(), maxiters = 1
 data_distributions = [fit_mle(Normal, aggregate_data[i, j, :]) for i in 1:2, j in 1:200]
 diff_distributions = [
     fit_mle(
-            Normal,
-            aggregate_data[i, j, :] - aggregate_data[i, j - 1, :]
-        )
+        Normal,
+        aggregate_data[i, j, :] - aggregate_data[i, j - 1, :]
+    )
         for j in 2:200, i in 1:2
 ]
 obj = build_loss_objective(
@@ -53,9 +53,9 @@ result = solve(optprob, BBO_adaptive_de_rand_1_bin_radiuslimited(), maxiters = 1
 data_distributions = [fit_mle(Normal, aggregate_data[i, j, :]) for i in 1:2, j in 1:200]
 diff_distributions = [
     fit_mle(
-            Normal,
-            aggregate_data[i, j, :] - aggregate_data[i, j - 1, :]
-        )
+        Normal,
+        aggregate_data[i, j, :] - aggregate_data[i, j - 1, :]
+    )
         for j in 2:200, i in 1:2
 ]
 obj = build_loss_objective(
@@ -79,9 +79,9 @@ result = solve(optprob, BBO_adaptive_de_rand_1_bin_radiuslimited(), maxiters = 1
 distributions = [fit_mle(MvNormal, aggregate_data[:, j, :]) for j in 1:200]
 diff_distributions = [
     fit_mle(
-            MvNormal,
-            aggregate_data[:, j, :] - aggregate_data[:, j - 1, :]
-        )
+        MvNormal,
+        aggregate_data[:, j, :] - aggregate_data[:, j - 1, :]
+    )
         for j in 2:200
 ]
 priors = [Truncated(Normal(1.5, 0.1), 0, 2), Truncated(Normal(1.0, 0.1), 0, 1.5)]


### PR DESCRIPTION
## What changed and why

Reformat the likelihood tests for Runic v1.10.0. Runic v1.10 changed generator-clause indentation, so the previously formatted file no longer passes the repository formatter check.

This is formatting-only; it makes no behavioral or public-API changes. Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

Failing before the change, on upstream `dca73d251b3942c5bed2eb8719e580b4b577f391`:

```text
$ julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 1]
```

Passing after the change:

```text
$ julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 0]

$ git diff --check
[exit 0]

$ typos test/likelihood.jl
[exit 0]

$ GROUP=QA julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Test Summary: | Pass  Total     Time
QA/qa.jl      |   20     20  1m15.8s
Testing DiffEqParamEstim tests passed
```

The complete `All` group was also run in a disposable validation worktree stacking the independent NLopt fix from https://github.com/SciML/DiffEqParamEstim.jl/pull/333. The changed likelihood group and the NLopt group both passed:

```text
Test Summary:       | Pass  Total   Time
Core/likelihood.jl  |    5      5  22.2s
Test Summary:       | Pass  Total   Time
Core/nlopt_test.jl  |    4      4  12.8s
```

That run later stopped at the independent stale `OptimizationSolution.minimizer` accessor in `two_stage_method_test.jl`. After stacking its fail-before/pass-after fix from https://github.com/SciML/DiffEqParamEstim.jl/pull/337 with the NLopt fix, the complete Core group passed:

```text
Test Summary: | Pass  Broken  Total
Core          |   43       1     44
```

## Not verified

Current upstream cannot finish Core until the independent base failures in https://github.com/SciML/DiffEqParamEstim.jl/pull/333 and https://github.com/SciML/DiffEqParamEstim.jl/pull/337 are applied. No GPU or downstream-package jobs outside the repository's declared groups were run.

## Reviewer note

The diff should contain only Runic's generator indentation changes in `test/likelihood.jl`.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d)
