### PR TITLE
Require Symbolics 7.39.2 (32-bit hasha_seed)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 
 [compat]
+Symbolics = "7.39.2"
 BlackBoxOptim = "0.6"
 CommonSolve = "0.2.6"
 DelayDiffEq = "6"
@@ -54,6 +55,7 @@ Zygote = "0.6, 0.7"
 julia = "1.10"
 
 [extras]
+Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 BlackBoxOptim = "a134a8b2-14d6-55f6-9291-3336d3ab0209"
 DelayDiffEq = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -77,4 +79,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Test", "BlackBoxOptim", "DelayDiffEq", "ForwardDiff", "Logging", "NLopt", "Optim", "Optimization", "OptimizationBBO", "OptimizationNLopt", "OptimizationOptimJL", "OrdinaryDiffEq", "OrdinaryDiffEqBDF", "Random", "SafeTestsets", "SciMLSensitivity", "SciMLTesting", "StochasticDiffEq", "SteadyStateDiffEq", "Sundials", "Zygote"]
+test = ["Symbolics", "Test", "BlackBoxOptim", "DelayDiffEq", "ForwardDiff", "Logging", "NLopt", "Optim", "Optimization", "OptimizationBBO", "OptimizationNLopt", "OptimizationOptimJL", "OrdinaryDiffEq", "OrdinaryDiffEqBDF", "Random", "SafeTestsets", "SciMLSensitivity", "SciMLTesting", "StochasticDiffEq", "SteadyStateDiffEq", "Sundials", "Zygote"]


### PR DESCRIPTION
## Summary
Force Symbolics ≥7.39.2 for i686 SymbolicUtils hasha_seed fix.

## Test plan
- [ ] x86 Core green

Made with [Cursor](https://cursor.com)