### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "OrdinaryDiffEq,StableRNGs,RecursiveArrayTools"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,45 @@
+using DiffEqParamEstim, OrdinaryDiffEq, BenchmarkTools
+using StableRNGs, RecursiveArrayTools
+
+const SUITE = BenchmarkGroup()
+const rng = StableRNG(123)
+
+# Lotka-Volterra with parameters to estimate
+function lotka!(du, u, p, t)
+    du[1] = p[1] * u[1] - u[1] * u[2]
+    du[2] = -p[2] * u[2] + u[1] * u[2]
+    return nothing
+end
+u0 = [1.0, 1.0]
+tspan = (0.0, 10.0)
+p_true = [1.5, 3.0]
+prob = ODEProblem(lotka!, u0, tspan, p_true)
+
+# Synthetic data from the true parameters
+data_t = collect(0.0:0.5:10.0)
+data_sol = solve(prob, Tsit5(); saveat = data_t)
+data = Array(data_sol)
+
+# =============================================================================
+# Loss objective construction and evaluation
+# =============================================================================
+
+SUITE["loss"] = BenchmarkGroup()
+
+l2 = L2Loss(data_t, data)
+cost_function = build_loss_objective(prob, Tsit5(), l2)
+
+SUITE["loss"]["build"] = @benchmarkable build_loss_objective($prob, Tsit5(), $l2)
+SUITE["loss"]["evaluate"] = @benchmarkable $cost_function($p_true)
+SUITE["loss"]["evaluate_perturbed"] = @benchmarkable $cost_function([1.6, 2.8])
+
+# =============================================================================
+# Regularized loss
+# =============================================================================
+
+SUITE["regularized"] = BenchmarkGroup()
+
+reg = L2Loss(data_t, data; differ_weight = 0.5, colloc_grad = nothing)
+SUITE["regularized"]["build"] = @benchmarkable build_loss_objective(
+    $prob, Tsit5(), $reg
+)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~13s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~13s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md