### PR TITLE
Import `transpose` from `Base` rather than `LinearAlgebra`

### DIFF
--- a/src/DiffEqParamEstim.jl
+++ b/src/DiffEqParamEstim.jl
@@ -5,7 +5,8 @@ import Dierckx
 using PenaltyFunctions: L2Penalty, value
 using RecursiveArrayTools: VectorOfArray
 using Distributions: UnivariateDistribution, logpdf
-using LinearAlgebra: Diagonal, mul!, transpose
+using Base: transpose
+using LinearAlgebra: Diagonal, mul!
 using SciMLBase: EnsembleProblem, OptimizationFunction, ReturnCode, isinplace, remake
 using Statistics: mean
 using StatsAPI: loglikelihood


### PR DESCRIPTION
## Summary

The QA job on the `julia '1'` lane (Julia 1.13.0) fails two ExplicitImports checks because `transpose` is imported from `LinearAlgebra`, while its owner is `Base`:

- `all_explicit_imports_via_owners`: `` `transpose` has owner `Base` but it was imported from `LinearAlgebra` ``
- `all_explicit_imports_are_public`: `` `transpose` is not public in `LinearAlgebra` ``

Failing run: https://github.com/SciML/DiffEqParamEstim.jl/actions/runs/34655433402

It is now imported from `Base`; `Diagonal` and `mul!` remain in the `LinearAlgebra` import.

## Test plan

- [x] `test/qa/qa.jl` passes 20/20 on Julia 1.13.0 (the two EI checks errored in CI on the unfixed code)
- [ ] CI

🤖 Generated with Devin CLI 3000.10.21 (model: SWE-2 Max). Session: local session, `/home/crackauc/.local/share/devin/cli/sessions.db`